### PR TITLE
Enable TLS

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"os/user"
 	"path"
 	"path/filepath"
 	"reflect"
@@ -29,6 +30,23 @@ func NewDogestryCli(cfg config.Config) (*DogestryCli, error) {
 	var err error
 	var newClient *docker.Client
 	dockerCertPath := os.Getenv("DOCKER_CERT_PATH")
+
+	usr, _ := user.Current()
+	homeDir := usr.HomeDir
+	dockerConfigDir := path.Join(homeDir, ".docker")
+
+	_, err = os.Stat(path.Join(dockerConfigDir, "cert.pem"))
+	certExists := err == nil
+
+	_, err = os.Stat(path.Join(dockerConfigDir, "ca.pem"))
+	caExists := err == nil
+
+	_, err = os.Stat(path.Join(dockerConfigDir, "key.pem"))
+	keyExists := err == nil
+
+	if dockerCertPath == "" && certExists && caExists && keyExists {
+		dockerCertPath = dockerConfigDir
+	}
 
 	if dockerCertPath != "" {
 		cert := path.Join(dockerCertPath, "cert.pem")


### PR DESCRIPTION
Enable TLS when connecting to the docker daemon, if one of the following is true:
1. The DOCKER_CERT_PATH environment variable is set
2.  Client keys (*.pem files) are found in the default location (~/.docker).
