### PR TITLE
Bubble up AWS error, if creating a new S3Client fails.

### DIFF
--- a/remote/s3.go
+++ b/remote/s3.go
@@ -35,7 +35,7 @@ var (
 func NewS3Remote(config RemoteConfig) (*S3Remote, error) {
 	s3, err := newS3Client(config)
 	if err != nil {
-		return &S3Remote{}, nil
+		return &S3Remote{}, err
 	}
 
 	url := config.Url


### PR DESCRIPTION
Return the error message from `goamz`, rather than crashing.
#### Before

```
$ ./dogestry push s3://<bucket> busybox 
Note: no config file found, using default config.
Using docker endpoint: tcp://localhost:2375
WorkDir: /var/folders/l8/g5bn82q153d4s747q_18dgbr0000gp/T/dogestry518011908/busybox
before newS3Client
before getS3Auth
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x80 pc=0x12494e]

goroutine 16 [running]:
runtime.panic(0x3b4b80, 0x61e1e4)
    /usr/local/Cellar/go/1.3.3/libexec/src/pkg/runtime/panic.c:279 +0xf5
github.com/crowdmob/goamz/s3.(*S3).Bucket(0x0, 0x0, 0x0, 0xc2080243f0)
    /Users/toffermann/go/src/github.com/crowdmob/goamz/s3/s3.go:101 +0x1e
github.com/dogestry/dogestry/remote.(*S3Remote).getBucket(0xc2080f0240, 0x100c1b0)
    /Users/toffermann/go/src/github.com/dogestry/dogestry/remote/s3.go:227 +0x41
github.com/dogestry/dogestry/remote.(*S3Remote).Validate(0xc2080f0240, 0x0, 0x0)
    /Users/toffermann/go/src/github.com/dogestry/dogestry/remote/s3.go:82 +0x4a
github.com/dogestry/dogestry/remote.NewRemote(0x7fff5fbffb18, 0x1a, 0xc2080243f0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
    /Users/toffermann/go/src/github.com/dogestry/dogestry/remote/remote.go:78 +0x272
github.com/dogestry/dogestry/cli.(*DogestryCli).CmdPush(0xc208038160, 0xc20800e020, 0x2, 0x2, 0x0, 0x0)
    /Users/toffermann/go/src/github.com/dogestry/dogestry/cli/push.go:36 +0x36a
reflect.callMethod(0xc208025860, 0xc2080e1d18)
    /usr/local/Cellar/go/1.3.3/libexec/src/pkg/reflect/value.go:761 +0x18b
reflect.methodValueCall(0xc20800e020, 0x2, 0x2, 0xc208025860, 0xc20800e301)
    /usr/local/Cellar/go/1.3.3/libexec/src/pkg/reflect/asm_amd64.s:26 +0x24
github.com/dogestry/dogestry/cli.(*DogestryCli).RunCmd(0xc208038160, 0xc20800e010, 0x3, 0x3, 0x0, 0x0)
    /Users/toffermann/go/src/github.com/dogestry/dogestry/cli/cli.go:96 +0x25c
main.main()
    /Users/toffermann/go/src/github.com/dogestry/dogestry/dogestry/main.go:37 +0x430

goroutine 19 [finalizer wait]:
runtime.park(0x14ae0, 0x621848, 0x6202a9)
    /usr/local/Cellar/go/1.3.3/libexec/src/pkg/runtime/proc.c:1369 +0x89
runtime.parkunlock(0x621848, 0x6202a9)
    /usr/local/Cellar/go/1.3.3/libexec/src/pkg/runtime/proc.c:1385 +0x3b
runfinq()
    /usr/local/Cellar/go/1.3.3/libexec/src/pkg/runtime/mgc0.c:2644 +0xcf
runtime.goexit()
    /usr/local/Cellar/go/1.3.3/libexec/src/pkg/runtime/proc.c:1445

goroutine 17 [syscall]:
runtime.goexit()
    /usr/local/Cellar/go/1.3.3/libexec/src/pkg/runtime/proc.c:1445
```
#### After

```
$ ./dogestry push s3://<bucket> busybox 
Note: no config file found, using default config.
Using docker endpoint: tcp://localhost:2375
WorkDir: /var/folders/l8/g5bn82q153d4s747q_18dgbr0000gp/T/dogestry495606771/busybox
2014/12/22 13:02:01 No valid AWS authentication found: open /Users/toffermann/.aws/credentials: no such file or directory
```

cc: @didip
