### PR TITLE
Capture error when loading docker image in cli.sendTar().

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -332,7 +332,10 @@ func (cli *DogestryCli) sendTar(imageRoot string) error {
 			}
 
 			fmt.Printf("Loading image to: %v\n", host)
-			client.LoadImage(docker.LoadImageOptions{InputStream: stdout})
+			err = client.LoadImage(docker.LoadImageOptions{InputStream: stdout})
+			if err != nil {
+				uploadImageErrMap[host] = err
+			}
 
 			wg.Done()
 


### PR DESCRIPTION
If an error happened during `client.LoadImage()`, it wasn't captured, so dogestry would report that everything was hunky dory, instead of halting as it should.
