### PR TITLE
Fix EOF error detection logic.

### DIFF
--- a/remote/s3.go
+++ b/remote/s3.go
@@ -121,7 +121,7 @@ func (remote *S3Remote) Push(image, imageRoot string) error {
 			for putFileArguments := range putFilesChan {
 				putFileErr := remote.putFile(putFileArguments.KeyDef.fullPath, &putFileArguments.KeyDef)
 
-				if (putFileErr != nil) && ((putFileErr != io.EOF) || (!strings.Contains(putFileErr.Error(), "EOF"))) {
+				if (putFileErr != nil) && ((putFileErr != io.EOF) && (!strings.Contains(putFileErr.Error(), "EOF"))) {
 					putFileErrMap[putFileArguments.Key] = putFileErr
 				}
 			}


### PR DESCRIPTION
putFile() will sometimes return an error of type *url.Error,
with the message of:

   Put <url>: EOF

We want to ignore those errors also.