### PR TITLE
Reformat progress reader output

### DIFF
--- a/cli/push.go
+++ b/cli/push.go
@@ -44,7 +44,7 @@ func (cli *DogestryCli) CmdPush(args ...string) error {
 		return err
 	}
 
-	fmt.Println("pushing image to remote")
+	fmt.Println("Pushing image to remote")
 	if err := remote.Push(image, imageRoot); err != nil {
 		return err
 	}

--- a/remote/s3.go
+++ b/remote/s3.go
@@ -131,7 +131,7 @@ func (remote *S3Remote) Push(image, imageRoot string) error {
 	}
 
 	for key, localKey := range keysToPush {
-		fmt.Printf("pushing key %s (%s)\n", key, utils.FileHumanSize(localKey.fullPath))
+		fmt.Printf("Pushing key %s (%s)\n", key, utils.FileHumanSize(localKey.fullPath))
 
 		keyDefClone := *localKey
 
@@ -371,7 +371,7 @@ func (remote *S3Remote) localKeysNotInRemote(imageRoot string) (keys, error) {
 		return nil, err
 	}
 
-	fmt.Println("calculating local keys to push")
+	fmt.Println("Calculating local keys to push")
 	keysToPush := localKeys.NotIn(remoteKeys)
 
 	return keysToPush, err
@@ -452,7 +452,7 @@ func (remote *S3Remote) getFiles(dst, rootKey string, imageKeys keys) error {
 
 // get a single file from the s3 bucket
 func (remote *S3Remote) getFile(dst string, key *keyDef) error {
-	fmt.Printf("pulling key %s (%s)\n", key.key, utils.HumanSize(key.s3Key.Size))
+	fmt.Printf("Pulling key %s (%s)\n", key.key, utils.HumanSize(key.s3Key.Size))
 
 	srcKey := remote.remoteKey(key.key)
 

--- a/remote/s3.go
+++ b/remote/s3.go
@@ -400,7 +400,7 @@ func (remote *S3Remote) putFile(src string, key *keyDef) error {
 		return err
 	}
 
-	progressReader := utils.NewProgressReader(f, finfo.Size(), os.Stdout)
+	progressReader := utils.NewProgressReader(f, finfo.Size(), src)
 
 	err = remote.getBucket().PutReader(dstKey, progressReader, finfo.Size(), "application/octet-stream", s3.Private, s3.Options{})
 	if err != nil {
@@ -473,7 +473,7 @@ func (remote *S3Remote) getFile(dst string, key *keyDef) error {
 	}
 
 	// TODO add progress reader
-	progressReaderFrom := utils.NewProgressReader(bufFrom, key.s3Key.Size, os.Stdout)
+	progressReaderFrom := utils.NewProgressReader(bufFrom, key.s3Key.Size, key.key)
 
 	_, err = io.Copy(to, progressReaderFrom)
 	if err != nil {

--- a/utils/progress.go
+++ b/utils/progress.go
@@ -1,12 +1,15 @@
 package utils
 
 import (
+	"fmt"
 	"io"
 	"log"
 	"os"
 )
 
 var progressLogger = log.New(os.Stdout, "", 0)
+
+var defaultInterval int64 = 1024 * 1024 * 10 // 10 MB
 
 type progressReader struct {
 	r              io.Reader
@@ -18,11 +21,12 @@ type progressReader struct {
 }
 
 func NewProgressReader(r io.Reader, size int64, fileName string) io.Reader {
-	return &progressReader{r, size, 0, 0, 1024 * 512, fileName}
+	return &progressReader{r, size, 0, 0, defaultInterval, fileName}
 }
 
 func printProgress(progress, total int64, fileName string) {
-	progressLogger.Printf("%s: %s/%s\n", fileName, HumanSize(progress), HumanSize(total))
+	calc := fmt.Sprintf("%s/%s", HumanSize(progress), HumanSize(total))
+	progressLogger.Printf("  %-17s : %s\n", calc, fileName)
 }
 
 func (p *progressReader) Read(in []byte) (n int, err error) {
@@ -37,9 +41,9 @@ func (p *progressReader) Read(in []byte) (n int, err error) {
 	if err != nil {
 		printProgress(p.Current, p.TotalSize, p.FileName)
 		if err == io.EOF {
-			progressLogger.Printf("done\n")
+			progressLogger.Printf("  %-17s : %s\n", "DONE", p.FileName)
 		} else {
-			progressLogger.Printf("error: %s\n", err)
+			progressLogger.Printf("  %-17s: %s: %v\n", "ERROR", p.FileName, err)
 		}
 	}
 

--- a/utils/progress.go
+++ b/utils/progress.go
@@ -1,25 +1,28 @@
 package utils
 
 import (
-	"fmt"
 	"io"
+	"log"
+	"os"
 )
+
+var progressLogger = log.New(os.Stdout, "", 0)
 
 type progressReader struct {
 	r              io.Reader
 	TotalSize      int64
-	Output         io.Writer
 	Current        int64
 	LastUpdate     int64
 	UpdateInterval int64
+	FileName       string
 }
 
-func NewProgressReader(r io.Reader, size int64, w io.Writer) io.Reader {
-	return &progressReader{r, size, w, 0, 0, 1024 * 512}
+func NewProgressReader(r io.Reader, size int64, fileName string) io.Reader {
+	return &progressReader{r, size, 0, 0, 1024 * 512, fileName}
 }
 
-func printProgress(w io.Writer, progress, total int64) {
-	fmt.Fprintf(w, "%s/%s         \r", HumanSize(progress), HumanSize(total))
+func printProgress(progress, total int64, fileName string) {
+	progressLogger.Printf("%s: %s/%s\n", fileName, HumanSize(progress), HumanSize(total))
 }
 
 func (p *progressReader) Read(in []byte) (n int, err error) {
@@ -27,17 +30,16 @@ func (p *progressReader) Read(in []byte) (n int, err error) {
 	p.Current += int64(n)
 
 	if p.Current-p.LastUpdate > p.UpdateInterval {
-		printProgress(p.Output, p.Current, p.TotalSize)
+		printProgress(p.Current, p.TotalSize, p.FileName)
 		p.LastUpdate = p.Current
 	}
 
 	if err != nil {
-		printProgress(p.Output, p.Current, p.TotalSize)
-		fmt.Fprintf(p.Output, "\n")
+		printProgress(p.Current, p.TotalSize, p.FileName)
 		if err == io.EOF {
-			fmt.Fprintf(p.Output, "done\n")
+			progressLogger.Printf("done\n")
 		} else {
-			fmt.Fprintf(p.Output, "error: %s\n", err)
+			progressLogger.Printf("error: %s\n", err)
 		}
 	}
 

--- a/utils/progress.go
+++ b/utils/progress.go
@@ -1,47 +1,45 @@
 package utils
 
 import (
-  "fmt"
-  "io"
+	"fmt"
+	"io"
 )
 
 type progressReader struct {
-  r io.Reader
-  TotalSize int64
-  Output io.Writer
-  Current int64
-  LastUpdate int64
-  UpdateInterval int64
+	r              io.Reader
+	TotalSize      int64
+	Output         io.Writer
+	Current        int64
+	LastUpdate     int64
+	UpdateInterval int64
 }
 
 func NewProgressReader(r io.Reader, size int64, w io.Writer) io.Reader {
-  return &progressReader{r, size, w, 0, 0, 1024*512}
+	return &progressReader{r, size, w, 0, 0, 1024 * 512}
 }
 
-
 func printProgress(w io.Writer, progress, total int64) {
-  fmt.Fprintf(w, "%s/%s         \r", HumanSize(progress), HumanSize(total))
+	fmt.Fprintf(w, "%s/%s         \r", HumanSize(progress), HumanSize(total))
 }
 
 func (p *progressReader) Read(in []byte) (n int, err error) {
-  n,err = p.r.Read(in)
-  p.Current += int64(n)
+	n, err = p.r.Read(in)
+	p.Current += int64(n)
 
-  if p.Current-p.LastUpdate > p.UpdateInterval {
-    printProgress(p.Output, p.Current, p.TotalSize)
-    p.LastUpdate = p.Current
-  }
+	if p.Current-p.LastUpdate > p.UpdateInterval {
+		printProgress(p.Output, p.Current, p.TotalSize)
+		p.LastUpdate = p.Current
+	}
 
+	if err != nil {
+		printProgress(p.Output, p.Current, p.TotalSize)
+		fmt.Fprintf(p.Output, "\n")
+		if err == io.EOF {
+			fmt.Fprintf(p.Output, "done\n")
+		} else {
+			fmt.Fprintf(p.Output, "error: %s\n", err)
+		}
+	}
 
-  if err != nil {
-    printProgress(p.Output, p.Current, p.TotalSize)
-    fmt.Fprintf(p.Output, "\n")
-    if err == io.EOF {
-      fmt.Fprintf(p.Output, "done\n")
-    } else {
-      fmt.Fprintf(p.Output, "error: %s\n", err)
-    }
-  }
-
-  return
+	return
 }


### PR DESCRIPTION
Rather than remove the progress reader output altogether (as I suggested in #7), I decided to reformat the output to make it more readable when being called from multiple goroutines concurrently.

Summary of changes

* Print a newline for every update (rather than rewriting same line)
* Include filename in each output line
* Make update interval 10 MB (output is still verbose, but a bit more reasonable with a larger interval)
* Use 'log' rather than 'fmt' (safer when printing from multiple goroutines)

cc: @didip @relistan @bryannewrelic

