### PR TITLE
Remove the check for empty directory to pull down tags. Fix #24.

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/dogestry/dogestry/config"
 	"github.com/dogestry/dogestry/remote"
-	"github.com/dogestry/dogestry/utils"
 	docker "github.com/fsouza/go-dockerclient"
 	homedir "github.com/mitchellh/go-homedir"
 )
@@ -334,19 +333,6 @@ func (cli *DogestryCli) outputStatus(errMap map[string]error) error {
 
 // sendTar streams exported tarball into remote docker hosts
 func (cli *DogestryCli) sendTar(imageRoot string) error {
-	notExist, err := utils.DirNotExistOrEmpty(imageRoot)
-
-	if err != nil {
-		return err
-	}
-
-	uploadImageErrMap := make(map[string]error)
-	if notExist {
-		fmt.Println("local directory is empty")
-		err = cli.outputStatus(uploadImageErrMap)
-		return err
-	}
-
 	type hostErrTuple struct {
 		host string
 		err  error
@@ -393,11 +379,12 @@ func (cli *DogestryCli) sendTar(imageRoot string) error {
 		close(tupleCh)
 	}()
 
+	uploadImageErrMap := make(map[string]error)
 	for tuple := range tupleCh {
 		uploadImageErrMap[tuple.host] = tuple.err
 	}
 
-	err = cli.outputStatus(uploadImageErrMap)
+	err := cli.outputStatus(uploadImageErrMap)
 	if len(uploadImageErrMap) > 0 {
 		err = errors.New("Error in sendTar")
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -67,28 +66,4 @@ func Sha1File(path string) (string, error) {
 
 	io.Copy(hash, buff)
 	return hex.EncodeToString(hash.Sum(nil)), nil
-}
-
-func DirNotExistOrEmpty(path string) (bool, error) {
-	imagesDir, err := os.Open(path)
-	if err != nil {
-		// no images
-		if os.IsNotExist(err) {
-			return true, nil
-		} else {
-			return false, err
-		}
-	}
-	defer imagesDir.Close()
-
-	names, err := ioutil.ReadDir(path)
-	if err != nil {
-		return false, err
-	}
-
-	if len(names) <= 1 {
-		return true, nil
-	}
-
-	return false, nil
 }


### PR DESCRIPTION
@toffer 

I've decided to remove the empty directory check entirely because that folder will never by empty since the repository file will always be downloaded. But this successfully creates the tags even if the image layers are same. 