### PR TITLE
Always update 'repositories/...' keys when pushing to S3.

### DIFF
--- a/remote/s3.go
+++ b/remote/s3.go
@@ -110,7 +110,7 @@ func (remote *S3Remote) Push(image, imageRoot string) error {
 	var err error
 
 	fmt.Println("Checking keys on S3 remote")
-	keysToPush, err := remote.localKeysNotInRemote(imageRoot)
+	keysToPush, err := remote.localKeysToPush(imageRoot)
 	if err != nil {
 		return fmt.Errorf("error calculating keys to push: %v", err)
 	}
@@ -375,7 +375,10 @@ func (remote *S3Remote) localKeys(root string) (keys, error) {
 	return localKeys, nil
 }
 
-func (remote *S3Remote) localKeysNotInRemote(imageRoot string) (keys, error) {
+// localKeysToPush checks each file in imageRoot to see if it already exists
+// in S3, or if it needs to be updated because its contents may have changed.
+// It returns a list of keys to push to S3.
+func (remote *S3Remote) localKeysToPush(imageRoot string) (keys, error) {
 	var err error
 
 	keysToPush := make(keys)

--- a/remote/s3.go
+++ b/remote/s3.go
@@ -400,6 +400,9 @@ func (remote *S3Remote) localKeysNotInRemote(imageRoot string) (keys, error) {
 			if !exists {
 				fmt.Printf("  not found: %v (%v)\n", k, utils.FileHumanSize(path))
 				resultsc <- k
+			} else if strings.HasPrefix(k, "repositories/") {
+				fmt.Printf("  stale    : %v (%v)\n", k, utils.FileHumanSize(path))
+				resultsc <- k
 			} else {
 				fmt.Printf("  exists   : %v (%v)\n", k, utils.FileHumanSize(path))
 			}


### PR DESCRIPTION
It doesn't matter if the `repositories/<image_name>/<tag_name>`
key already exists in S3. Because the contents can change, we
must always make sure to upload the new key every time we push
an image, so that the metadata for the image/tag is always up
to date.

Fixes #32.

cc: @amjith @didip 