### PR TITLE
Dial back concurrency

### DIFF
--- a/dogestry/main.go
+++ b/dogestry/main.go
@@ -42,8 +42,6 @@ func init() {
 }
 
 func main() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
-
 	flag.Parse()
 
 	if flVersion {

--- a/remote/s3.go
+++ b/remote/s3.go
@@ -129,7 +129,7 @@ func (remote *S3Remote) Push(image, imageRoot string) error {
 	putFileErrMap := make(map[string]error)
 	putFilesChan := makeFilesChan(keysToPush)
 
-	numGoroutines := 100
+	numGoroutines := 5
 
 	var wg sync.WaitGroup
 


### PR DESCRIPTION
We should test this out, and see what kind of a difference it makes to reduce the number of CPUs used, as well as the number of goroutines used to push files to S3.

cc: @amjith @didip