### PR TITLE
Add list command

### DIFF
--- a/cli/list.go
+++ b/cli/list.go
@@ -1,0 +1,35 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/dogestry/dogestry/remote"
+)
+
+func (cli *DogestryCli) CmdList(args ...string) error {
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	defer w.Flush()
+
+	remoteDef := args[0]
+
+	r, err := remote.NewRemote(remoteDef, cli.Config)
+	if err != nil {
+		return err
+	}
+
+	images, err := r.List()
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(w, "REPOSITORY\tTAG\n")
+
+	for _, i := range images {
+		line := fmt.Sprintf("%s\t%s", i.Repository, i.Tag)
+		fmt.Fprintln(w, line)
+	}
+
+	return nil
+}

--- a/cli/list.go
+++ b/cli/list.go
@@ -8,11 +8,31 @@ import (
 	"github.com/dogestry/dogestry/remote"
 )
 
+const ListHelpMessage string = `  List images on REMOTE.
+
+  Arguments:
+    REMOTE       Name of REMOTE.
+
+  Examples:
+    dogestry list s3://DockerBucket/Path/?region=us-east-1
+    dogestry list /path/to/images`
+
 func (cli *DogestryCli) CmdList(args ...string) error {
+	listFlags := cli.Subcmd("list", "REMOTE", ListHelpMessage)
+	if err := listFlags.Parse(args); err != nil {
+		return nil
+	}
+
+	if len(listFlags.Args()) < 1 {
+		fmt.Fprintln(cli.err, "Error: REMOTE not specified")
+		listFlags.Usage()
+		os.Exit(2)
+	}
+
+	remoteDef := listFlags.Arg(0)
+
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
 	defer w.Flush()
-
-	remoteDef := args[0]
 
 	r, err := remote.NewRemote(remoteDef, cli.Config)
 	if err != nil {

--- a/remote/local.go
+++ b/remote/local.go
@@ -111,6 +111,10 @@ func (remote *LocalRemote) ImageMetadata(id ID) (docker.Image, error) {
 	return image, nil
 }
 
+func (remote *LocalRemote) ParseImagePath(path string, prefix string) (repo, tag string) {
+	return ParseImagePath(path, prefix)
+}
+
 func (remote *LocalRemote) rsyncTo(src, dst string) error {
 	return remote.rsync(src+"/", remote.RemotePath(dst)+"/")
 }
@@ -135,4 +139,35 @@ func (remote *LocalRemote) imagePath(id ID) string {
 
 func (remote *LocalRemote) RemotePath(part ...string) string {
 	return filepath.Join(remote.Path, filepath.Join(part...))
+}
+
+func (remote *LocalRemote) List() (images []Image, err error) {
+	imagesRoot := filepath.Join(filepath.Clean(remote.Url.Path), "repositories")
+	_, err = os.Open(imagesRoot)
+	if err != nil {
+		return images, err
+	}
+
+	pathList := []string{}
+	err = filepath.Walk(imagesRoot, func(path string, info os.FileInfo, _ error) error {
+		if !info.IsDir() {
+			pathList = append(pathList, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return images, err
+	}
+
+	for _, path := range pathList {
+		repo, tag := remote.ParseImagePath(path, imagesRoot+"/")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error splitting repository key\n")
+			return images, err
+		}
+		image := Image{repo, tag}
+		images = append(images, image)
+	}
+
+	return images, nil
 }

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -26,6 +26,11 @@ type RemoteConfig struct {
 	Url    url.URL
 }
 
+type Image struct {
+	Repository string
+	Tag        string
+}
+
 type ImageWalkFn func(id ID, image docker.Image, err error) error
 
 type Remote interface {
@@ -45,6 +50,9 @@ type Remote interface {
 
 	ImageMetadata(id ID) (docker.Image, error)
 
+	// return repo, tag from a file path (or S3 key)
+	ParseImagePath(path string, prefix string) (repo, tag string)
+
 	// walk the image history on the remote, starting at id
 	WalkImages(id ID, walker ImageWalkFn) error
 
@@ -53,6 +61,9 @@ type Remote interface {
 
 	// describe the remote
 	Desc() string
+
+	// List images on the remote
+	List() ([]Image, error)
 }
 
 func NewRemote(remoteName string, config config.Config) (remote Remote, err error) {
@@ -148,6 +159,14 @@ func ResolveImageNameToId(remote Remote, image string) (ID, error) {
 	}
 
 	return "", ErrNoSuchImage
+}
+
+func ParseImagePath(path string, prefix string) (repo, tag string) {
+	path = strings.TrimPrefix(path, prefix)
+	parts := strings.Split(path, "/")
+	repo = strings.Join(parts[:len(parts)-1], "/")
+	tag = parts[len(parts)-1]
+	return repo, tag
 }
 
 // Common implementation of walking a remote's images

--- a/remote/s3.go
+++ b/remote/s3.go
@@ -234,6 +234,10 @@ func (remote *S3Remote) ImageMetadata(id ID) (docker.Image, error) {
 	return image, nil
 }
 
+func (remote *S3Remote) ParseImagePath(path string, prefix string) (repo, tag string) {
+	return ParseImagePath(path, prefix)
+}
+
 // get the configured bucket
 func (remote *S3Remote) getBucket() *s3.Bucket {
 	// memoise?
@@ -559,4 +563,44 @@ func (remote *S3Remote) imagePath(id ID) string {
 
 func (remote *S3Remote) remoteKey(key string) string {
 	return key
+}
+
+func (remote *S3Remote) List() (images []Image, err error) {
+
+	bucket := remote.getBucket()
+	nextMarker := ""
+
+	var contents []s3.Key
+
+	for true {
+		resp, err := bucket.List("repositories/", "", nextMarker, 1000)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s unable to list images: %s", remote.Desc(), err)
+			return images, err
+		}
+
+		contents = append(contents, resp.Contents...)
+
+		if resp.IsTruncated {
+			nextMarker = resp.NextMarker
+		} else {
+			break
+		}
+	}
+
+	for _, k := range contents {
+		if strings.HasSuffix(k.Key, ".sum") {
+			continue
+		}
+		repo, tag := remote.ParseImagePath(k.Key, "repositories/")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error splitting repository key")
+			return images, err
+		}
+
+		image := Image{repo, tag}
+		images = append(images, image)
+	}
+
+	return images, nil
 }


### PR DESCRIPTION
I've kept the output simple, with just columns for `REPOSITORY` and `TAG`. To add more columns would require one or more queries to S3 per image, so I've decided to keep the output simple, in order to make the `list` command very responsive.

Here's what the output looks like:

    $ dogestry list /srv/dogestry-remote/
    REPOSITORY        TAG
    busybox           latest
    progrium/busybox  foo

Fixes #26.

cc: @didip @amjith @relistan 