### PR TITLE
Optimize docker export

### DIFF
--- a/cli/push.go
+++ b/cli/push.go
@@ -63,9 +63,15 @@ func (cli *DogestryCli) CmdPush(args ...string) error {
 	return nil
 }
 
+// There's no Set data structure in Go, so use a map to simulate one.
+type set map[remote.ID]struct{}
+
+// We don't use the value in a set, so it's always empty.
+var empty struct{}
+
 // Stream the tarball from docker and translate it into the portable repo format
 // Note that its easier to handle as a stream on the way out.
-func (cli *DogestryCli) exportImageToFiles(image, root string, saveIds map[remote.ID]struct{}) error {
+func (cli *DogestryCli) exportImageToFiles(image, root string, saveIds set) error {
 	fmt.Printf("Exporting image: %v to: %v\n", image, root)
 
 	reader, writer := io.Pipe()
@@ -215,10 +221,7 @@ func (cli *DogestryCli) exportToFiles(image string, r remote.Remote, imageRoot s
 	// Check the remote to see what layers are missing. Only missing Ids will
 	// need to be saved to disk when exporting the docker image.
 
-	// There's no Set data structure in Go, so use a map with an empty struct
-	// as the value to simulate one.
-	var empty struct{}
-	missingIds := make(map[remote.ID]struct{})
+	missingIds := make(set)
 
 	for _, i := range imageHistory {
 		id := remote.ID(i.ID)

--- a/cli/push.go
+++ b/cli/push.go
@@ -52,12 +52,10 @@ func (cli *DogestryCli) CmdPush(args ...string) error {
 	fmt.Printf("Using docker endpoint for push: %v\n", cli.DockerHost)
 	fmt.Printf("Remote: %v\n", remote.Desc())
 
-	fmt.Println("Exporting files")
 	if err = cli.exportToFiles(image, remote, imageRoot); err != nil {
 		return err
 	}
 
-	fmt.Println("Pushing image to remote")
 	if err := remote.Push(image, imageRoot); err != nil {
 		return err
 	}
@@ -209,6 +207,8 @@ func (cli *DogestryCli) exportToFiles(image string, r remote.Remote, imageRoot s
 		fmt.Printf("Error getting image history: %v\n", err)
 	}
 
+	fmt.Println("Checking layers on remote")
+
 	imageID := remote.ID(imageHistory[0].ID)
 	repoName, repoTag := remote.NormaliseImageName(image)
 
@@ -222,10 +222,11 @@ func (cli *DogestryCli) exportToFiles(image string, r remote.Remote, imageRoot s
 
 	for _, i := range imageHistory {
 		id := remote.ID(i.ID)
-		fmt.Printf("  checking id: %v\n", id)
 		_, err = r.ImageMetadata(id)
-		if err != nil {
-			fmt.Printf("    not found: %v\n", id)
+		if err == nil {
+			fmt.Printf("  exists   : %v\n", id)
+		} else {
+			fmt.Printf("  not found: %v\n", id)
 			missingIds[id] = empty
 		}
 	}


### PR DESCRIPTION
Before we export the docker image, we check to see what layers are already present on the remote.

That way, if we know we won't have to upload a file to the remote, we don't have to write it to disk. Rather, when reading the tarball stream, we can discard unneeded files, and only write the ones we need to upload.

Fixes #36.

cc: @amjith @didip @relistan 