### PR TITLE
Add lock file parameter

### DIFF
--- a/cli/help.go
+++ b/cli/help.go
@@ -16,6 +16,7 @@ const HelpMessage string = `Usage: dogestry [OPTIONS] COMMAND [arg...]
   Options:
      -config     Path to optional config file
      -pullhosts  A comma-separated list of docker hosts where the image will be pulled
+     -lockfile   Path to optional lock file to use, prevents parallel execution
 
   Typical S3 Usage:
      dogestry push s3://<bucket name>/<path name>/?region=us-east-1 <image name>


### PR DESCRIPTION
This helps with preventing multiple executions at the same time which
in some environments (Cheap Amazon default EBS) will make Docker go
nuts and forget about some layers when stressed too hard.

I'm using this to prevent Docker daemon from messing up its layers when pulling 10 containers at the same time on a small instance on Amazon EC2. See https://github.com/docker/docker/issues/9997 for an example of what might happen.