### PR TITLE
Always export metadata during push.

### DIFF
--- a/cli/push.go
+++ b/cli/push.go
@@ -234,14 +234,15 @@ func (cli *DogestryCli) exportToFiles(image string, r remote.Remote, imageRoot s
 		}
 	}
 
-	if len(missingIds) == 0 {
-		if err := cli.exportMetaDataToFiles(repoName, repoTag, imageID, imageRoot); err != nil {
-			return err
-		}
-	} else {
+	if len(missingIds) > 0 {
 		if err := cli.exportImageToFiles(image, imageRoot, missingIds); err != nil {
 			return err
 		}
 	}
+
+	if err := cli.exportMetaDataToFiles(repoName, repoTag, imageID, imageRoot); err != nil {
+		return err
+	}
+
 	return nil
 }


### PR DESCRIPTION
Currently, if you push an existing tag with changed layers, the metadata doesn't get updated. This PR fixes that, so that the metadata is always updated on every push.

This is significant bug, so it should go into a release as soon as possible. (After careful review, of course!)

Fixes #46.

cc: @didip @relistan 