### PR TITLE
Clean up the wait logic. Always push something into the channel.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,12 +2,12 @@
 
 set -e
 
-d="sudo docker"
+[[ -z $DOCKER ]] && DOCKER=docker
 
 # don't rm intermediate containers... we want them!
-$d build --rm=false -t dogestry .
-id=$($d inspect -f '{{ .container }}' dogestry)
-$d cp $id:dogestry .
+$DOCKER build --rm=false -t dogestry .
+id=$($DOCKER inspect -f '{{ .container }}' dogestry)
+$DOCKER cp $id:dogestry .
 
 if [ -f "./push.sh" ]; then
   ./push.sh


### PR DESCRIPTION
By always putting something into the channel we can remove all the waitgroups and we don't run any risk of missing stuff. It seems that in some cases the last entry in the channel was getting
missed when it was closed.

sidekicked by @didip 