### PR TITLE
Fix environment variables in usage example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,8 +23,8 @@ If you prefer to build it yourself, clone the repo and `godep go build`
 
 Typical S3 Usage:
 ```
-$ export AWS_ACCESS_KEY=ABC
-$ export AWS_SECRET_KEY=DEF
+$ export AWS_ACCESS_KEY_ID=ABC
+$ export AWS_SECRET_ACCESS_KEY=DEF
 $ export DOCKER_HOST=tcp://localhost:2375
 $ dogestry push s3://<bucket name>/<path name>/?region=us-east-1 <image name>
 $ dogestry pull s3://<bucket name>/<path name>/?region=us-east-1 <image name>


### PR DESCRIPTION
cc @didip

The AWS_ACCESS_KEY and AWS_SECRET_KEY envvars in the README don't work
anymore.