### PR TITLE
Ability to use metadata service for credentials

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -10,7 +10,7 @@ import (
 var hosts = make([]string, 0)
 
 func TestNewDogestryCli(t *testing.T) {
-	cfg, err := config.NewConfig()
+	cfg, err := config.NewConfig(false)
 	if err != nil {
 		t.Fatalf("Creating dogestry config should work. Error: %v", err)
 	}
@@ -26,7 +26,7 @@ func TestNewDogestryCli(t *testing.T) {
 }
 
 func TestCreateAndReturnTempDirAndCleanup(t *testing.T) {
-	cfg, err := config.NewConfig()
+	cfg, err := config.NewConfig(false)
 	if err != nil {
 		t.Fatalf("Creating dogestry config should work. Error: %v", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -6,7 +6,7 @@ import (
 	"os"
 )
 
-func NewConfig() (Config, error) {
+func NewConfig(useMetaService bool) (Config, error) {
 	c := Config{}
 	c.AWS.AccessKeyID = os.Getenv("AWS_ACCESS_KEY_ID")
 	if c.AWS.AccessKeyID == "" {
@@ -24,7 +24,7 @@ func NewConfig() (Config, error) {
 		c.Docker.Connection = "unix:///var/run/docker.sock"
 	}
 
-	if c.AWS.AccessKeyID == "" || c.AWS.SecretAccessKey == "" {
+	if !useMetaService && (c.AWS.AccessKeyID == "" || c.AWS.SecretAccessKey == "") {
 		return c, errors.New("AWS_ACCESS_KEY_ID/AWS_ACCESS_KEY or AWS_SECRET_ACCESS_KEY/AWS_SECRET_KEY are missing.")
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,15 +1,35 @@
 package config
 
 import (
+	"os"
 	"testing"
 )
 
 func TestNewConfig(t *testing.T) {
-	c, err := NewConfig()
+	os.Setenv("AWS_ACCESS_KEY_ID", "access")
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "secret")
+	c, err := NewConfig(false)
 	if err != nil {
 		t.Fatalf("Failed to create config. Error: %v", err)
 	}
+	if c.AWS.AccessKeyID != "access" {
+		t.Error("AccessKeyID should be 'access': " + c.AWS.AccessKeyID)
+	}
+	if c.AWS.SecretAccessKey != "secret" {
+		t.Error("SecretAccessKey should be 'secret': " + c.AWS.SecretAccessKey)
+	}
 	if c.Docker.Connection == "" {
 		t.Error("config.Docker.Connection should not be empty.")
+	}
+
+	os.Unsetenv("AWS_SECRET_ACCESS_KEY")
+	c, err = NewConfig(false)
+	if err == nil || err.Error() != "AWS_ACCESS_KEY_ID/AWS_ACCESS_KEY or AWS_SECRET_ACCESS_KEY/AWS_SECRET_KEY are missing." {
+		t.Error("should return error when evn vars are not set")
+	}
+
+	c, err = NewConfig(true)
+	if err != nil {
+		t.Error("should not renturn an error")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -27,10 +27,11 @@ func (h *pullHosts) Set(value string) error {
 }
 
 var (
-	flConfigFile string
-	flVersion    bool
-	flPullHosts  pullHosts
-	flLockFile   string
+	flConfigFile     string
+	flVersion        bool
+	flPullHosts      pullHosts
+	flLockFile       string
+	flUseMetaService bool
 )
 
 func init() {
@@ -44,6 +45,7 @@ func init() {
 	flag.BoolVar(&flVersion, "v", versionDefault, versionUsage+" (short)")
 	flag.Var(&flPullHosts, "pullhosts", "a comma-separated list of docker hosts where the image will be pulled")
 	flag.StringVar(&flLockFile, "lockfile", "", "lockfile to use while executing command, prevents parallel executions")
+	flag.BoolVar(&flUseMetaService, "use-metaservice", false, "use tha AWS metadata service to get credentials")
 }
 
 func main() {
@@ -65,7 +67,7 @@ func main() {
 
 	args := flag.Args()
 
-	cfg, err := config.NewConfig()
+	cfg, err := config.NewConfig(flUseMetaService)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/remote/s3_test.go
+++ b/remote/s3_test.go
@@ -41,7 +41,7 @@ func (s *S) SetUpSuite(c *C) {
 
 	s.TempDir = tempDir
 
-	baseConfig, err := config.NewConfig()
+	baseConfig, err := config.NewConfig(false)
 	if err != nil {
 		c.Fatalf("couldn't initialize config. Error: %s", err)
 	}


### PR DESCRIPTION
This PR adds a flag to use the AWS metadata service for credentials. At the moment it only bypasses the check of the AWS environment variables, but an idea for the future could be to check for the availability of credentials from the metadata service in NewConfig().