### PR TITLE
Use instance keys for s3gof3r if flag use-metaservice is passed

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,8 @@ func NewConfig(useMetaService bool) (Config, error) {
 		c.Docker.Connection = "unix:///var/run/docker.sock"
 	}
 
+	c.AWS.UseMetaService = useMetaService
+
 	if !useMetaService && (c.AWS.AccessKeyID == "" || c.AWS.SecretAccessKey == "") {
 		return c, errors.New("AWS_ACCESS_KEY_ID/AWS_ACCESS_KEY or AWS_SECRET_ACCESS_KEY/AWS_SECRET_KEY are missing.")
 	}
@@ -36,6 +38,7 @@ type Config struct {
 		S3URL           *url.URL
 		AccessKeyID     string
 		SecretAccessKey string
+		UseMetaService  bool
 	}
 	Docker struct {
 		Connection string

--- a/remote/s3.go
+++ b/remote/s3.go
@@ -25,7 +25,10 @@ func NewS3Remote(config config.Config) (*S3Remote, error) {
 		return &S3Remote{}, err
 	}
 
-	s3gof3rKeys := s3gof3r.Keys{AccessKey: config.AWS.AccessKeyID, SecretKey: config.AWS.SecretAccessKey}
+	s3gof3rKeys, err := getS3gof3rKeys(config)
+	if err != nil {
+		return &S3Remote{}, err
+	}
 
 	return &S3Remote{
 		config:               config,
@@ -46,6 +49,14 @@ type S3Remote struct {
 var (
 	S3DefaultRegion = "us-east-1"
 )
+
+func getS3gof3rKeys(config config.Config) (s3gof3r.Keys, error) {
+	if config.AWS.UseMetaService {
+		return s3gof3r.InstanceKeys()
+	} else {
+		return s3gof3r.Keys{AccessKey: config.AWS.AccessKeyID, SecretKey: config.AWS.SecretAccessKey}, nil
+	}
+}
 
 // create a new s3 client from the url
 func newS3Client(config config.Config) (*s3.S3, error) {


### PR DESCRIPTION
# What

When trying to use EC2 instance metadata to push an image, I was getting this error:
```
$ dogestry -use-metaservice push s3://my-bucket-name/ my-image-name

... other stuff before error ...

Pushing files to S3 remote:
2015/07/24 00:41:13 error when uploading to S3: 403: "The AWS Access Key Id you provided does not exist in our records."
{"Status":"error", "Message": "Error when uploading to S3: 403: "The AWS Access Key Id you provided does not exist in our records.""}
```
It appears that dogestry is using two different s3 clients, and while s3gof3r supports getting the Instance Keys, dogestry was not telling it to do so, when passing the -use-metaservice flag. 

This tells s3gof3r to get the keys from ec2 instance metadata if that flag is passed. Now I no longer get the error, and my image is on S3! Sweet victory.