### PR TITLE
Use docker cliconfig package to load and save logins

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -2,11 +2,15 @@ package cli
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/docker/docker/cliconfig"
+	homedir "github.com/mitchellh/go-homedir"
 )
 
 const LoginHelpMessage string = `  Save AWS credentials for REGISTRY.
@@ -16,6 +20,11 @@ const LoginHelpMessage string = `  Save AWS credentials for REGISTRY.
 
   Examples:
     dogestry login registry.example.com`
+
+type CompatConfigFile struct {
+	*cliconfig.ConfigFile
+	filename string
+}
 
 func (cli *DogestryCli) CmdLogin(args ...string) error {
 	loginFlags := cli.Subcmd("login", "REMOTE", LoginHelpMessage)
@@ -32,12 +41,12 @@ func (cli *DogestryCli) CmdLogin(args ...string) error {
 	url := loginFlags.Arg(0)
 
 	// Try to locate a docker config
-	dockerCfg, cfgErr := cliconfig.Load("")
+	dockerCfg, cfgErr := CompatLoad()
 	if cfgErr != nil {
 		return cfgErr
 	}
 
-	fmt.Printf("Updating docker file %v...\n", dockerCfg.Filename())
+	fmt.Printf("Updating docker file %v...\n", dockerCfg.filename)
 
 	// Get input
 	loginInfo, inputErr := GetLoginInput()
@@ -56,7 +65,7 @@ func (cli *DogestryCli) CmdLogin(args ...string) error {
 	dockerCfg.AuthConfigs[url] = authconfig
 
 	// Update docker config
-	if err := dockerCfg.Save(); err != nil {
+	if err := dockerCfg.CompatSave(); err != nil {
 		return err
 	}
 
@@ -82,4 +91,84 @@ func GetLoginInput() (map[string]string, error) {
 	}
 
 	return loginInfo, nil
+}
+
+func (configFile *CompatConfigFile) CompatSave() error {
+	if strings.HasSuffix(configFile.filename, ".dockercfg") {
+		if err := os.MkdirAll(filepath.Dir(configFile.filename), 0700); err != nil {
+			return err
+		}
+		f, err := os.OpenFile(configFile.filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		return configFile.LegacySaveToWriter(f)
+	}
+
+	return configFile.Save()
+}
+
+func (configFile *CompatConfigFile) LegacySaveToWriter(writer io.Writer) error {
+	// Encode sensitive data into a new/temp struct
+	tmpAuthConfigs := make(map[string]cliconfig.AuthConfig, len(configFile.AuthConfigs))
+	for k, authConfig := range configFile.AuthConfigs {
+		authCopy := authConfig
+		// encode and save the authstring, while blanking out the original fields
+		authCopy.Auth = cliconfig.EncodeAuth(&authCopy)
+		authCopy.Username = ""
+		authCopy.Password = ""
+		authCopy.ServerAddress = ""
+		tmpAuthConfigs[k] = authCopy
+	}
+
+	saveAuthConfigs := configFile.AuthConfigs
+	configFile.AuthConfigs = tmpAuthConfigs
+	defer func() { configFile.AuthConfigs = saveAuthConfigs }()
+
+	data, err := json.MarshalIndent(configFile.AuthConfigs, "", "\t")
+	if err != nil {
+		return err
+	}
+	_, err = writer.Write(data)
+	return err
+}
+
+func CompatLoad() (*CompatConfigFile, error) {
+	dockerCfg := cliconfig.NewConfigFile(filepath.Join(cliconfig.ConfigDir(), cliconfig.ConfigFileName))
+	configFile := CompatConfigFile{
+		dockerCfg,
+		dockerCfg.Filename(),
+	}
+
+	// Try .docker/config.json first
+	if _, err := os.Stat(configFile.filename); err == nil {
+		file, err := os.Open(configFile.filename)
+		if err != nil {
+			return &configFile, err
+		}
+		defer file.Close()
+		err = configFile.LoadFromReader(file)
+		return &configFile, err
+	} else if !os.IsNotExist(err) {
+		return &configFile, err
+	}
+
+	// Try the old .dockercfg
+	homeDir, _ := homedir.Dir()
+	configFile.filename = filepath.Join(homeDir, ".dockercfg")
+	if _, err := os.Stat(configFile.filename); err != nil {
+		return &configFile, nil //missing file is not an error
+	}
+	file, err := os.Open(configFile.filename)
+	if err != nil {
+		return &configFile, err
+	}
+	defer file.Close()
+	err = configFile.LegacyLoadFromReader(file)
+	if err != nil {
+		return &configFile, err
+	}
+
+	return &configFile, nil
 }


### PR DESCRIPTION
Newer versions of Docker (1.7 onwards) use `~/.docker/config.json` to store login information. The current logic seems to be looking at the wrong path (`config` instead of `config.json`). Additionally, the format of the json file has changed; all logins are now nested inside the `auths` property.

This changes the login comand to use the updated functions from `github/docker/docker/cliconfig` for loading and saving docker configs. I had to add some code to support writing to the old `.dockercfg` format as well, based on which file was loaded.