### PR TITLE
Dselans/docker alive check

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -7,15 +7,19 @@ import (
 	"github.com/dogestry/dogestry/config"
 )
 
+const (
+	testTmpDirRoot string = "/tmp"
+)
+
 var hosts = make([]string, 0)
 
 func TestNewDogestryCli(t *testing.T) {
-	cfg, err := config.NewConfig(false, 22375, false, false)
+	cfg, err := config.NewConfig(false, 22375, false, false, false)
 	if err != nil {
 		t.Fatalf("Creating dogestry config should work. Error: %v", err)
 	}
 
-	dogestryCli, err := NewDogestryCli(cfg, hosts)
+	dogestryCli, err := NewDogestryCli(cfg, hosts, testTmpDirRoot)
 	if err != nil {
 		t.Fatalf("Creating dogestryCli struct should work. Error: %v", err)
 	}
@@ -26,14 +30,18 @@ func TestNewDogestryCli(t *testing.T) {
 }
 
 func TestCreateAndReturnTempDirAndCleanup(t *testing.T) {
-	cfg, err := config.NewConfig(false, 22375, false, false)
+	cfg, err := config.NewConfig(false, 22375, false, false, false)
 	if err != nil {
 		t.Fatalf("Creating dogestry config should work. Error: %v", err)
 	}
 
-	dogestryCli, _ := NewDogestryCli(cfg, hosts)
+	dogestryCli, _ := NewDogestryCli(cfg, hosts, testTmpDirRoot)
 
-	tmpDir := dogestryCli.CreateAndReturnTempDir()
+	tmpDir, err := dogestryCli.CreateAndReturnTempDir()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
 	if tmpDir == "" {
 		t.Fatalf("CreateAndReturnTempDir should always return path to tmp directory. tmpDir: %v", tmpDir)
 	}

--- a/cli/help.go
+++ b/cli/help.go
@@ -7,23 +7,24 @@ import (
 const HelpMessage string = `Usage: dogestry [OPTIONS] COMMAND [arg...]
 
   Commands:
-     help          Print help message. Use help COMMAND for more specific help
-     list          List images on remote
-     pull          Pull IMAGE from remote and load it into docker
-     push          Push IMAGE from docker to remote
-     remote        Show info about remote
-     version       Print version
-     login         Add your AWS credentials to your .dockercfg (similar to 'docker login')
+     help             Print help message. Use help COMMAND for more specific help
+     list             List images on remote
+     pull             Pull IMAGE from remote and load it into docker
+     push             Push IMAGE from docker to remote
+     remote           Show info about remote
+     version          Print version
+     login            Add your AWS credentials to your .dockercfg (similar to 'docker login')
 
   Options:
-     -config       Path to optional config file
-     -pullhosts    A comma-separated list of docker hosts where the image will be pulled
-     -lockfile     Path to optional lock file to use, prevents parallel execution
-     -server       Run dogestry in server mode
-     -address      What address to bind to for dogestry server mode (default: 0.0.0.0)
-     -port         What port to use for dogestry server (default: 22375)
-     -force-local  Do *not* attempt to utilize remote Dogestry servers (default: false)
-     -tempdir      What directory dogestry will use for stroring temporary files
+     -config          Path to optional config file
+     -pullhosts       A comma-separated list of docker hosts where the image will be pulled
+     -lockfile        Path to optional lock file to use, prevents parallel execution
+     -server          Run dogestry in server mode
+     -address         What address to bind to for dogestry server mode (default: 0.0.0.0)
+     -port            What port to use for dogestry server (default: 22375)
+     -force-local     Do *not* attempt to utilize remote Dogestry servers (default: false)
+     -tempdir         What directory dogestry will use for stroring temporary files
+     -disable-checks  Disable health checking of remote Docker hosts during 'pull'
 
   Typical S3 Usage:
      dogestry push s3://<bucket name>/<path name>/?region=us-east-1 <image name>

--- a/config/config.go
+++ b/config/config.go
@@ -13,7 +13,7 @@ const (
 	S3DefaultRegion string = "us-east-1"
 )
 
-func NewConfig(useMetaService bool, serverPort int, forceLocal, requireEnvVars bool) (Config, error) {
+func NewConfig(useMetaService bool, serverPort int, forceLocal, requireEnvVars, disableChecks bool) (Config, error) {
 	c := Config{}
 	c.AWS.AccessKeyID = os.Getenv("AWS_ACCESS_KEY_ID")
 	if c.AWS.AccessKeyID == "" {
@@ -41,6 +41,7 @@ func NewConfig(useMetaService bool, serverPort int, forceLocal, requireEnvVars b
 
 	c.ServerPort = serverPort
 	c.ForceLocal = forceLocal
+	c.DisableChecks = disableChecks
 
 	return c, nil
 }
@@ -95,9 +96,10 @@ type AuthConfig struct {
 }
 
 type Config struct {
-	ServerMode bool
-	ServerPort int
-	ForceLocal bool // whether to attempt remote dogestry server usage
+	ServerMode    bool
+	ServerPort    int
+	ForceLocal    bool // whether to attempt remote dogestry server usage
+	DisableChecks bool // whether to health check Docker hosts prior to pull(s)
 
 	AWS struct {
 		S3URL           *url.URL

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -8,7 +8,7 @@ import (
 func TestNewConfig(t *testing.T) {
 	os.Setenv("AWS_ACCESS_KEY_ID", "access")
 	os.Setenv("AWS_SECRET_ACCESS_KEY", "secret")
-	c, err := NewConfig(false, 22375, false, true)
+	c, err := NewConfig(false, 22375, false, true, false)
 	if err != nil {
 		t.Fatalf("Failed to create config. Error: %v", err)
 	}
@@ -27,12 +27,12 @@ func TestNewConfig(t *testing.T) {
 	os.Unsetenv("AWS_SECRET_ACCESS_KEY")
 	os.Unsetenv("AWS_SECRET_KEY")
 
-	c, err = NewConfig(false, 22375, false, true)
+	c, err = NewConfig(false, 22375, false, true, false)
 	if err == nil || err.Error() != "AWS_ACCESS_KEY_ID/AWS_ACCESS_KEY or AWS_SECRET_ACCESS_KEY/AWS_SECRET_KEY are missing." {
 		t.Error("should return error when evn vars are not set")
 	}
 
-	c, err = NewConfig(true, 22375, false, false)
+	c, err = NewConfig(true, 22375, false, false, false)
 	if err != nil {
 		t.Error("should not renturn an error")
 	}

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ var (
 	flServerPort     int
 	flForceLocal     bool
 	flTempDir        string
+	flDisableChecks  bool
 )
 
 func init() {
@@ -57,6 +58,7 @@ func init() {
 	flag.IntVar(&flServerPort, "port", 22375, "what port to bind to when running dogestry in server mode")
 	flag.BoolVar(&flForceLocal, "force-local", false, "do not try to use the dogestry server on host endpoints")
 	flag.StringVar(&flTempDir, "tempdir", "", "where to store temporary files created by dogestry")
+	flag.BoolVar(&flDisableChecks, "disable-checks", false, "disable health checking of remote Docker hosts during 'pull'")
 }
 
 func main() {
@@ -92,7 +94,7 @@ func main() {
 			requireEnvVars = false
 		}
 
-		cfg, err := config.NewConfig(flUseMetaService, flServerPort, flForceLocal, requireEnvVars)
+		cfg, err := config.NewConfig(flUseMetaService, flServerPort, flForceLocal, requireEnvVars, flDisableChecks)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/remote/s3_test.go
+++ b/remote/s3_test.go
@@ -41,7 +41,7 @@ func (s *S) SetUpSuite(c *C) {
 
 	s.TempDir = tempDir
 
-	baseConfig, err := config.NewConfig(false, 22375, false, false)
+	baseConfig, err := config.NewConfig(false, 22375, false, false, false)
 	if err != nil {
 		c.Fatalf("couldn't initialize config. Error: %s", err)
 	}


### PR DESCRIPTION
This PR contains the following changes:

Docker host health checking prior to pulls (seeking status code 200 on host:port/version GET
Ability to disable host health checking via -disable-checks CLI flag
Refactored dogestry server check code to work for both docker and dogestry endpoints
Adapted ParseHostnames -> ParseHosts to return a host->port map (map[string]int)
Fixes #94

@talpert @intjonathan @idleyoungman