### PR TITLE
bugfix for pull

### DIFF
--- a/cli/pull.go
+++ b/cli/pull.go
@@ -83,6 +83,11 @@ func (cli *DogestryCli) CheckHosts(hosts map[string]int, timeout time.Duration, 
 
 	if !docker {
 		service = "Dogestry"
+
+		// Do not check for running dogestry server(s) if hosts are empty
+		if len(hosts) == 0 {
+			return fmt.Errorf("Hosts empty - nothing to check")
+		}
 	}
 
 	for host, port := range hosts {


### PR DESCRIPTION
CheckHosts() would return true (that dogestry server is running) if 'hosts' was empty.

Updated CheckHosts() to return an error if:

- hosts is empty AND we are performing a dogestry check

@talpert