### PR TITLE
Fix some channel handling nastiness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Ignore the binary produced by `go build`
 dogestry
+.swp
+.swo


### PR DESCRIPTION
There are a few problems with the way channels and concurrency work in the Push code. This PR fixes:

1. Some spelling errors
2. Simplify things by removing the need for quit channels
3. Don't leak open channels
4. Refactor for readability
5. Actually quit pushing when the first error occurs

cc @didip @dselans 