### PR TITLE
Extend check timeout; release 2.1.6

### DIFF
--- a/cli/pull.go
+++ b/cli/pull.go
@@ -53,7 +53,7 @@ func (cli *DogestryCli) CmdPull(args ...string) error {
 	}
 
 	hosts := utils.ParseHosts(cli.PullHosts)
-	checkTimeout := time.Duration(1) * time.Second
+	checkTimeout := time.Duration(10) * time.Second
 
 	// Perform docker health check (if -disable-checks is disabled (default))
 	if !cli.Config.DisableChecks {

--- a/cli/version.go
+++ b/cli/version.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-const Version string = "2.1.5"
+const Version string = "2.1.6"
 
 func PrintVersion() error {
 	_, err := fmt.Printf("Dogestry %s\n", Version)


### PR DESCRIPTION
* Extend timeout of the docker health check from one second to ten
* Bump version for release

CC @talpert @yonatan-schultz