### PR TITLE
Strip hash function from docker image hash value

### DIFF
--- a/remote/id.go
+++ b/remote/id.go
@@ -1,15 +1,27 @@
 package remote
 
+import (
+	"strings"
+)
+
 type ID string
 
+// stripPrefix removes hashing definition that we are not interested in here.
+// Also makes sure as to not break backwards compatibility with older versions
+// where Docker did not specify the hash function.
+func (id ID) trimPrefix() ID {
+	return ID(strings.TrimPrefix(string(id), "sha256:"))
+}
+
 func (id ID) Short() ID {
+	id = id.trimPrefix()
 	shortLen := 12
 	if len(id) < shortLen {
 		shortLen = len(id)
 	}
-	return id[:shortLen]
+	return ID(id[:shortLen])
 }
 
 func (id ID) String() string {
-	return string(id)
+	return string(id.trimPrefix())
 }


### PR DESCRIPTION
Pulling in a commit on a fork from @balboah:

> This confuses the path names that dogestry uses in S3 and breaks compatibility
with previous version of Docker.

Necessary for modern versions of Docker that stick the hash function name at the beginning of the hash.